### PR TITLE
feat: Announcements page

### DIFF
--- a/app/announcements/page.tsx
+++ b/app/announcements/page.tsx
@@ -1,0 +1,50 @@
+// app/announcements/page.tsx
+import { prisma } from "@/lib/prisma";
+import { format } from "date-fns";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+async function getAnnouncements() {
+  return prisma.announcement.findMany({
+    orderBy: { publishedAt: "desc" }
+  });
+}
+
+export default async function AnnouncementsPage() {
+  const announcements = await getAnnouncements();
+
+  return (
+    <div className="container mx-auto py-6">
+      <h1 className="text-3xl font-bold mb-6">Announcements</h1>
+
+      <div className="space-y-4">
+        {announcements.length === 0 && <p>No announcements yet. Check back again later!</p>}
+
+        {announcements.map((a) => {
+          const authorName = a.authorName;
+          const pubStr = format(new Date(a.publishedAt), "PPP p");
+          const dateStr = format(new Date(a.updatedAt), "PPP p");
+
+          return (
+            <article key={a.id} className="p-4 border rounded-md shadow-md">
+              <header className="flex-col items-center justify-start space-x-4 mb-3">
+                <div>
+                  <div className="text-lg">{authorName}</div>
+                </div>
+                <div>
+                    <span className="italic text-sm text-muted-foreground">Published: <time>{pubStr}</time></span>
+                    <br/>
+                    <span className="italic text-sm text-muted-foreground">Updated: <time>{dateStr}</time></span>
+                </div>
+              </header>
+              <hr />
+              <div className="mt-3 prose max-w-none">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{a.content}</ReactMarkdown>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/api/announcement/route.ts
+++ b/app/api/announcement/route.ts
@@ -1,0 +1,142 @@
+// app/api/announcements/route.ts
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/lib/prisma";
+
+const SECRET = process.env.ANNOUNCEMENT_SECRET;
+
+export async function POST(request: Request) {
+  const headerSecret = request.headers.get("x-announcement-secret") || (() => {
+    const auth = request.headers.get("authorization") || "";
+    return auth.startsWith("Bearer ") ? auth.slice(7) : null;
+  })();
+
+  if (!SECRET || headerSecret !== SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { content, publishedAt, authorId } = body;
+  let { authorName } = body;
+  if (!content) {
+    return NextResponse.json({ error: "Missing required fields: body" }, { status: 400 });
+  }
+  if (typeof content !== "string") {
+    return NextResponse.json({ error: "Invalid field types" }, { status: 400 });
+  }
+
+  try {
+    const account = await prisma.account.findFirst({
+      where: { providerAccountId: authorId }
+    });
+    if (account) {
+      const info = await prisma.participantInfo.findFirst({
+        where: { userId: account.userId }
+      });
+      authorName = info?.firstName + " " + info?.lastName.substring(0, 1) || authorName;
+    }
+    const created = await prisma.announcement.create({
+      data: {
+        content: content,
+        authorId: authorId,
+        authorName: authorName,
+        publishedAt: publishedAt ? new Date(publishedAt) : new Date(),
+      },
+    });
+    revalidatePath("/announcements");
+
+    return NextResponse.json({
+      ...created,
+      publishedAt: created.publishedAt.toISOString(),
+      updatedAt: created.updatedAt.toISOString(),
+    });
+  } catch (err) {
+    console.error("POST /api/announcements error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: Request) {
+  const headerSecret = request.headers.get("x-announcement-secret") || (() => {
+    const auth = request.headers.get("authorization") || "";
+    return auth.startsWith("Bearer ") ? auth.slice(7) : null;
+  })();
+
+  if (!SECRET || headerSecret !== SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { id, content } = body;
+  if (!content) {
+    return NextResponse.json({ error: "Missing required fields: content" }, { status: 400 });
+  }
+  if (typeof content !== "string") {
+    return NextResponse.json({ error: "Invalid field types" }, { status: 400 });
+  }
+
+  try {
+    const updated = await prisma.announcement.update({
+      where: { id: id },
+      data: {
+        content: content,
+      },
+    });
+    revalidatePath("/announcements");
+
+    return NextResponse.json({
+      ...updated,
+      publishedAt: updated.publishedAt.toISOString(),
+      updatedAt: updated.updatedAt.toISOString(),
+    });
+  } catch (err) {
+    console.error("PATCH /api/announcements error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request) {
+  const headerSecret = request.headers.get("x-announcement-secret") || (() => {
+    const auth = request.headers.get("authorization") || "";
+    return auth.startsWith("Bearer ") ? auth.slice(7) : null;
+  })();
+
+  if (!SECRET || headerSecret !== SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { id } = body;
+  if (!id) {
+    return NextResponse.json({ error: "Missing required fields: id" }, { status: 400 });
+  }
+
+  try {
+    await prisma.announcement.delete({
+      where: { id: id },
+    });
+    revalidatePath("/announcements");
+    
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("DELETE /api/announcements error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/prisma/migrations/20260411212757_add_announcements/migration.sql
+++ b/prisma/migrations/20260411212757_add_announcements/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "Announcement" (
+    "id" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "publishedAt" TIMESTAMP(3) NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Announcement_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/migrations/20260411213936_add_announcements/migration.sql
+++ b/prisma/migrations/20260411213936_add_announcements/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `body` on the `Announcement` table. All the data in the column will be lost.
+  - You are about to drop the column `createdAt` on the `Announcement` table. All the data in the column will be lost.
+  - Added the required column `content` to the `Announcement` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Announcement" DROP COLUMN "body",
+DROP COLUMN "createdAt",
+ADD COLUMN     "content" TEXT NOT NULL,
+ALTER COLUMN "publishedAt" SET DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/migrations/20260411214818_add_announcements/migration.sql
+++ b/prisma/migrations/20260411214818_add_announcements/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `authorName` to the `Announcement` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Announcement" ADD COLUMN     "authorName" TEXT NOT NULL;

--- a/prisma/migrations/20260411221653_add_announcements/migration.sql
+++ b/prisma/migrations/20260411221653_add_announcements/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `publishedAt` on the `Announcement` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Announcement" DROP COLUMN "publishedAt";

--- a/prisma/migrations/20260411222926_add_announcements/migration.sql
+++ b/prisma/migrations/20260411222926_add_announcements/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Announcement" ADD COLUMN     "publishedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -291,3 +291,12 @@ model InfoPageContent {
   logoUrl       String?
   updatedAt     DateTime @updatedAt
 }
+
+model Announcement { 
+  id String @id @default(cuid())
+  content String
+  authorId String
+  authorName String
+  publishedAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}


### PR DESCRIPTION
This adds an announcements page to /announcements and an API endpoint at /api/announcement. The goal of this PR is to automatically upload announcements from the Discord server into the website database so that they can be viewed without logging into Discord.
This is the first draft of this feature, but I do believe it is complete.